### PR TITLE
[dsch] implementation of Result::asTuple

### DIFF
--- a/src/Err.ts
+++ b/src/Err.ts
@@ -105,6 +105,9 @@ export class ErrImpl<E> implements Err<E> {
   apply() {
     return this;
   }
+  asTuple(): readonly [ok: false, value: undefined, error: E] {
+    return [false, undefined, this.error] as const;
+  }
 }
 
 Object.defineProperty(ErrImpl, 'name', { enumerable: false, value: 'Err' });

--- a/src/Ok.ts
+++ b/src/Ok.ts
@@ -107,6 +107,9 @@ export class OkImpl<T> implements Ok<T> {
 
     return Array.isArray(argValues) ? ok(this.value(...argValues)) : argValues;
   }
+  asTuple(): readonly [ok: true, value: T, error: undefined] {
+    return [true, this.value, undefined] as const;
+  }
 }
 
 Object.defineProperty(OkImpl, 'name', { enumerable: false, value: 'Ok' });

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1243,4 +1243,258 @@ describe('Result', () => {
       ).toEqual(ok([1, 'foo']));
     });
   });
+
+  describe('asTuple', () => {
+    it('returns a tuple for an Ok result', () => {
+      expect.assertions(2);
+      const [isOk, value, error] = ok('foo').asTuple();
+
+      if (isOk) {
+        expect(value).toBe('foo');
+        expect(error).toBeUndefined();
+      }
+    });
+
+    it('returns a tuple for an Ok result - pipe', () => {
+      expect.assertions(2);
+      const [isOk, value, error] = pipe(ok('foo'), R.asTuple);
+
+      if (isOk) {
+        expect(value).toBe('foo');
+        expect(error).toBeUndefined();
+      }
+    });
+
+    it('returns a correctly typed tuple for an Ok result', () => {
+      const result = ok('foo');
+      const [isOk, value, error] = result.asTuple();
+
+      const checkStatus: Expect<Equal<typeof isOk, true>> = true;
+      expect(checkStatus).toBe(true);
+
+      const checkValue: Expect<Equal<typeof value, string>> = true;
+      expect(checkValue).toBe(true);
+
+      const checkError: Expect<Equal<typeof error, undefined>> = true;
+      expect(checkError).toBe(true);
+    });
+
+    it('returns a correctly typed tuple for an Ok result - pipe', () => {
+      const result = ok('foo');
+      const [isOk, value, error] = pipe(result, R.asTuple);
+
+      const checkStatus: Expect<Equal<typeof isOk, boolean>> = true;
+      expect(checkStatus).toBe(true);
+
+      const checkValue: Expect<Equal<typeof value, string | undefined>> = true;
+      expect(checkValue).toBe(true);
+
+      const checkError: Expect<Equal<typeof error, undefined>> = true;
+      expect(checkError).toBe(true);
+    });
+
+    it('returns a tuple for an Ok result typed as Result', () => {
+      expect.assertions(2);
+      const result = ok('foo') as Result<string, 'ERR'>;
+      const [isOk, value, error] = result.asTuple();
+
+      if (isOk) {
+        expect(value).toBe('foo');
+        expect(error).toBeUndefined();
+      }
+    });
+
+    it('returns a tuple for an Ok result typed as Result - pipe', () => {
+      expect.assertions(2);
+      const result = ok('foo') as Result<string, 'ERR'>;
+      const [isOk, value, error] = pipe(result, R.asTuple);
+
+      if (isOk) {
+        expect(value).toBe('foo');
+        expect(error).toBeUndefined();
+      }
+    });
+
+    it('returns a correctly typed tuple for an Ok result typed as Result', () => {
+      const result = ok('foo') as Result<string, 'ERR'>;
+      const [isOk, value, error] = result.asTuple();
+
+      const checkStatus: Expect<Equal<typeof isOk, boolean>> = true;
+      expect(checkStatus).toBe(true);
+
+      const checkValue: Expect<Equal<typeof value, string | undefined>> = true;
+      expect(checkValue).toBe(true);
+
+      const checkError: Expect<Equal<typeof error, 'ERR' | undefined>> = true;
+      expect(checkError).toBe(true);
+    });
+
+    it('returns a correctly typed tuple for an Ok result typed as Result - pipe', () => {
+      const result = ok('foo') as Result<string, 'ERR'>;
+      const [isOk, value, error] = pipe(result, R.asTuple);
+
+      const checkStatus: Expect<Equal<typeof isOk, boolean>> = true;
+      expect(checkStatus).toBe(true);
+
+      const checkValue: Expect<Equal<typeof value, string | undefined>> = true;
+      expect(checkValue).toBe(true);
+
+      const checkError: Expect<Equal<typeof error, 'ERR' | undefined>> = true;
+      expect(checkError).toBe(true);
+    });
+
+    it('returns a tuple that could correctly discriminated for an Ok result typed as Result', () => {
+      expect.assertions(2);
+      const result = ok('foo') as Result<string, 'ERR'>;
+      const [isOk, value, error] = result.asTuple();
+
+      if (isOk) {
+        const checkValue: Expect<Equal<typeof value, string>> = true;
+        expect(checkValue).toBe(true);
+
+        const checkError: Expect<Equal<typeof error, undefined>> = true;
+        expect(checkError).toBe(true);
+      }
+    });
+
+    it('returns a tuple that could correctly discriminated for an Ok result typed as Result - pipe', () => {
+      expect.assertions(2);
+      const result = ok('foo') as Result<string, 'ERR'>;
+      const [isOk, value, error] = pipe(result, R.asTuple);
+
+      if (isOk) {
+        const checkValue: Expect<Equal<typeof value, string>> = true;
+        expect(checkValue).toBe(true);
+
+        const checkError: Expect<Equal<typeof error, undefined>> = true;
+        expect(checkError).toBe(true);
+      }
+    });
+
+    it('returns a tuple for an Err result', () => {
+      expect.assertions(2);
+      const [isOk, value, error] = err('foo').asTuple();
+
+      if (!isOk) {
+        expect(value).toBeUndefined();
+        expect(error).toBe('foo');
+      }
+    });
+
+    it('returns a tuple for an Err result - pipe', () => {
+      expect.assertions(2);
+      const [isOk, value, error] = pipe(err('foo'), R.asTuple);
+
+      if (!isOk) {
+        expect(value).toBeUndefined();
+        expect(error).toBe('foo');
+      }
+    });
+
+    it('returns a correctly typed tuple for an Err result', () => {
+      const result = err('foo');
+      const [isOk, value, error] = result.asTuple();
+
+      const checkStatus: Expect<Equal<typeof isOk, false>> = true;
+      expect(checkStatus).toBe(true);
+
+      const checkValue: Expect<Equal<typeof value, undefined>> = true;
+      expect(checkValue).toBe(true);
+
+      const checkError: Expect<Equal<typeof error, string>> = true;
+      expect(checkError).toBe(true);
+    });
+
+    it('returns a correctly typed tuple for an Err result - pipe', () => {
+      const result = err('foo');
+      const [isOk, value, error] = pipe(result, R.asTuple);
+
+      const checkStatus: Expect<Equal<typeof isOk, boolean>> = true;
+      expect(checkStatus).toBe(true);
+
+      const checkValue: Expect<Equal<typeof value, unknown>> = true;
+      expect(checkValue).toBe(true);
+
+      const checkError: Expect<Equal<typeof error, string | undefined>> = true;
+      expect(checkError).toBe(true);
+    });
+
+    it('returns a tuple for an Err result typed as Result', () => {
+      expect.assertions(2);
+      const result = err('ERR') as Result<string, 'ERR'>;
+      const [isOk, value, error] = result.asTuple();
+
+      if (!isOk) {
+        expect(value).toBeUndefined();
+        expect(error).toBe('ERR');
+      }
+    });
+
+    it('returns a tuple for an Err result typed as Result - pipe', () => {
+      expect.assertions(2);
+      const result = err('ERR') as Result<string, 'ERR'>;
+      const [isOk, value, error] = pipe(result, R.asTuple);
+
+      if (!isOk) {
+        expect(value).toBeUndefined();
+        expect(error).toBe('ERR');
+      }
+    });
+
+    it('returns a correctly typed tuple for an Err result typed as Result', () => {
+      const result = err('ERR') as Result<string, 'ERR'>;
+      const [isOk, value, error] = result.asTuple();
+
+      const checkStatus: Expect<Equal<typeof isOk, boolean>> = true;
+      expect(checkStatus).toBe(true);
+
+      const checkValue: Expect<Equal<typeof value, string | undefined>> = true;
+      expect(checkValue).toBe(true);
+
+      const checkError: Expect<Equal<typeof error, 'ERR' | undefined>> = true;
+      expect(checkError).toBe(true);
+    });
+
+    it('returns a correctly typed tuple for an Err result typed as Result - pipe', () => {
+      const result = err('ERR') as Result<string, 'ERR'>;
+      const [isOk, value, error] = pipe(result, R.asTuple);
+
+      const checkStatus: Expect<Equal<typeof isOk, boolean>> = true;
+      expect(checkStatus).toBe(true);
+
+      const checkValue: Expect<Equal<typeof value, string | undefined>> = true;
+      expect(checkValue).toBe(true);
+
+      const checkError: Expect<Equal<typeof error, 'ERR' | undefined>> = true;
+      expect(checkError).toBe(true);
+    });
+
+    it('returns a tuple that could correctly discriminated for an Err result typed as Result', () => {
+      expect.assertions(2);
+      const result = err('ERR') as Result<string, 'ERR'>;
+      const [isOk, value, error] = result.asTuple();
+
+      if (!isOk) {
+        const checkValue: Expect<Equal<typeof value, undefined>> = true;
+        expect(checkValue).toBe(true);
+
+        const checkError: Expect<Equal<typeof error, 'ERR'>> = true;
+        expect(checkError).toBe(true);
+      }
+    });
+
+    it('returns a tuple that could correctly discriminated for an Err result typed as Result - pipe', () => {
+      expect.assertions(2);
+      const result = err('ERR') as Result<string, 'ERR'>;
+      const [isOk, value, error] = pipe(result, R.asTuple);
+
+      if (!isOk) {
+        const checkValue: Expect<Equal<typeof value, undefined>> = true;
+        expect(checkValue).toBe(true);
+
+        const checkError: Expect<Equal<typeof error, 'ERR'>> = true;
+        expect(checkError).toBe(true);
+      }
+    });
+  });
 });

--- a/src/sync-methods.ts
+++ b/src/sync-methods.ts
@@ -81,3 +81,11 @@ export const biChain =
   ) =>
   (result: Result<T, E>): Result<TS | ES, TF | EF> =>
     result.biChain(okFn, errFn);
+
+export const asTuple: {
+  <T, E>(
+    result: Result<T, E>,
+  ):
+    | readonly [ok: true, value: T, error: undefined]
+    | readonly [ok: false, value: undefined, error: E];
+} = (result: Result<unknown, unknown>): any => result.asTuple();

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,12 +2,14 @@ export interface Ok<T> extends ResultInterface<T, never> {
   readonly value: T;
   readonly isOk: true;
   readonly isErr: false;
+  asTuple(): readonly [ok: true, value: T, error: undefined];
 }
 
 export interface Err<E> extends ResultInterface<never, E> {
   readonly error: E;
   readonly isOk: false;
   readonly isErr: true;
+  asTuple(): readonly [ok: false, value: undefined, error: E];
 }
 
 export interface ResultInterface<T, E> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `asTuple` methods in `Ok` and `Err` classes to provide structured representations of success and error states.
	- Added a new `asTuple` function for handling `Result` types, simplifying the process of checking results.
- **Tests**
	- Expanded test coverage for the `asTuple` method, ensuring correctness and type safety for both `Ok` and `Err` results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->